### PR TITLE
fixed some ui issues with register activity

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,8 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.10" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -10,7 +10,7 @@
         android:layout_centerInParent="true"
         android:paddingTop="70dp"
         android:layout_width="320dp"
-        android:layout_height="390dp">
+        android:layout_height="400dp">
         <android.support.v7.widget.CardView
             android:id="@+id/cv_add"
             app:cardBackgroundColor="#2ea67f"
@@ -46,6 +46,7 @@
                    <android.support.design.widget.TextInputLayout
                        android:textColorHint="#f0f7f4"
                        android:layout_width="match_parent"
+                       android:theme="@style/TextLabel"
                        android:layout_height="wrap_content">
                        <EditText
                            android:textSize="13sp"
@@ -70,6 +71,7 @@
                    <android.support.design.widget.TextInputLayout
 
                        android:textColorHint="#f0f7f4"
+                       android:theme="@style/TextLabel"
                        android:layout_width="match_parent"
                        android:layout_height="wrap_content">
                        <EditText
@@ -95,6 +97,7 @@
                    <android.support.design.widget.TextInputLayout
 
                        android:textColorHint="#f0f7f4"
+                       android:theme="@style/TextLabel"
                        android:layout_width="match_parent"
                        android:layout_height="wrap_content">
                        <EditText

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,4 +15,8 @@
         <item name="android:windowIsTranslucent">true</item>
 
     </style>
+    <style name="TextLabel" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- Label color in TRUE state and bar color FALSE and TRUE State -->
+        <item name="colorControlActivated">#FFCC00</item>
+    </style>
 </resources>


### PR DESCRIPTION
the end of the register activity was being cut off fixed by increasing the frame layout height.
changed the register TextEdit floating label into (orange) for a better look
